### PR TITLE
Removed refs to token contract. count() -> getCount()

### DIFF
--- a/migrations/2_contract_migration.js
+++ b/migrations/2_contract_migration.js
@@ -1,7 +1,5 @@
 const CounterContract = artifacts.require("CounterContract");
-const WasmTokenContract = artifacts.require("WasmTokenContract");
 
 module.exports = function(deployer) {
   deployer.deploy(CounterContract);
-  deployer.deploy(WasmTokenContract, 100);
 }

--- a/test/test-counter.js
+++ b/test/test-counter.js
@@ -9,14 +9,14 @@ contract("CounterContract", (accounts) => {
   });
 
   it("should have a count of zero", async () => {
-    const count = await instance.methods.count().call();
+    const count = await instance.methods.getCount().call();
 
     assert.equal(count, 0);
   });
 
   it("should increment by one", async () => {
     await instance.methods.increment().send();
-    const count = await instance.methods.count().call();
+    const count = await instance.methods.getCount().call();
 
     assert.equal(count, 1);
   })


### PR DESCRIPTION
The migrations script has reference to the token contract which is not there anymore. Also, the function `count()` should be `getCount()`.