### PR TITLE
Remove big endian assumption

### DIFF
--- a/contracts/my_counter/src/lib.rs
+++ b/contracts/my_counter/src/lib.rs
@@ -17,7 +17,7 @@ trait CounterContract {
     #[constant]
     fn getCount(&mut self) -> U256 {
         debug("Getting count");
-        U256::from_big_endian(&owasm_ethereum::read(&COUNTER_KEY))
+        U256::from(&owasm_ethereum::read(&COUNTER_KEY))
     }
 
     fn increment(&mut self) {


### PR DESCRIPTION
As @nhynes pointed out in a related [ganymede PR](https://github.com/oasislabs/ganymede/pull/10),we should not assume that data is stored as big endian.

Replaced from_big_endian() with from(), and all local tests build and pass on oasis devnet.